### PR TITLE
Add protection where clause to ElementCollections of Embeddable entities as well

### DIFF
--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPACollectionJoinQuery.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPACollectionJoinQuery.java
@@ -301,7 +301,7 @@ public class JPACollectionJoinQuery extends JPAAbstractJoinQuery {
       }
     }
     
-    whereCondition = addWhereClause(super.createWhere(uriResource, navigationInfo), createProtectionWhere(claimsProvider));
+    whereCondition = addWhereClause(whereCondition, createProtectionWhere(claimsProvider));
     
     debugger.stopRuntimeMeasurement(handle);
     return whereCondition;

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPACollectionJoinQuery.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPACollectionJoinQuery.java
@@ -300,6 +300,9 @@ public class JPACollectionJoinQuery extends JPAAbstractJoinQuery {
         }
       }
     }
+    
+    whereCondition = addWhereClause(super.createWhere(uriResource, navigationInfo), createProtectionWhere(claimsProvider));
+    
     debugger.stopRuntimeMeasurement(handle);
     return whereCondition;
   }


### PR DESCRIPTION
As an initial mitigation to the performance problems described here: https://github.com/SAP/olingo-jpa-processor-v4/issues/154 we can add protection where clause to sub-entities as well in order to limit the response for a dedicated tenancy as well. Otherwise the whole tables are loaded in memory for entities that we are sure won't match any of the parent entities due to protection restrictions.