### PR TITLE
The sybase jdbc driver returns a integer as count result.

### DIFF
--- a/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/api/EntityManagerFactoryWrapper.java
+++ b/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/api/EntityManagerFactoryWrapper.java
@@ -14,41 +14,48 @@ import jakarta.persistence.metamodel.Metamodel;
 
 import com.sap.olingo.jpa.metadata.core.edm.mapper.api.JPAServiceDocument;
 import com.sap.olingo.jpa.processor.cb.impl.EntityManagerWrapper;
+import com.sap.olingo.jpa.processor.cb.impl.SqlPagingFunctions;
 
 public final class EntityManagerFactoryWrapper implements EntityManagerFactory {
   private final EntityManagerFactory emf;
   private final JPAServiceDocument sd;
+  private final SqlPagingFunctions sqlPagingFunctions;
 
-  public EntityManagerFactoryWrapper(final EntityManagerFactory emf, final JPAServiceDocument sd) {
+  public EntityManagerFactoryWrapper(final EntityManagerFactory emf, final JPAServiceDocument sd, final SqlPagingFunctions sqlPagingFunctions) {
     super();
     this.emf = emf;
     this.sd = sd;
+    if ( sqlPagingFunctions == null ) {
+      this.sqlPagingFunctions = new SqlPagingFunctions();
+    } else {
+      this.sqlPagingFunctions = sqlPagingFunctions;
+    }
   }
 
   @Override
   public EntityManager createEntityManager() {
-    return new EntityManagerWrapper(emf.createEntityManager(), sd);
+    return new EntityManagerWrapper(emf.createEntityManager(), sd,sqlPagingFunctions);
   }
 
   @Override
   public EntityManager createEntityManager(@SuppressWarnings("rawtypes") final Map map) {
-    return new EntityManagerWrapper(emf.createEntityManager(map), sd);
+    return new EntityManagerWrapper(emf.createEntityManager(map), sd, sqlPagingFunctions);
   }
 
   @Override
   public EntityManager createEntityManager(final SynchronizationType synchronizationType) {
-    return new EntityManagerWrapper(emf.createEntityManager(synchronizationType), sd);
+    return new EntityManagerWrapper(emf.createEntityManager(synchronizationType), sd, sqlPagingFunctions);
   }
 
   @Override
   public EntityManager createEntityManager(final SynchronizationType synchronizationType,
       @SuppressWarnings("rawtypes") final Map map) {
-    return new EntityManagerWrapper(emf.createEntityManager(synchronizationType, map), sd);
+    return new EntityManagerWrapper(emf.createEntityManager(synchronizationType, map), sd, sqlPagingFunctions);
   }
 
   @Override
   public CriteriaBuilder getCriteriaBuilder() {
-    try (EntityManager em = new EntityManagerWrapper(emf.createEntityManager(), sd)) {
+    try (EntityManager em = new EntityManagerWrapper(emf.createEntityManager(), sd, sqlPagingFunctions)) {
       return em.getCriteriaBuilder();
     }
   }

--- a/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/impl/CriteriaBuilderImpl.java
+++ b/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/impl/CriteriaBuilderImpl.java
@@ -48,10 +48,12 @@ class CriteriaBuilderImpl implements ProcessorCriteriaBuilder { // NOSONAR
 
   private final JPAServiceDocument sd;
   private final ParameterBuffer parameter;
+  private final SqlPagingFunctions sqlPagingFunctions;
 
-  CriteriaBuilderImpl(final JPAServiceDocument sd, final ParameterBuffer parameterBuffer) {
+  CriteriaBuilderImpl(final JPAServiceDocument sd, final ParameterBuffer parameterBuffer, final SqlPagingFunctions sqlPagingFunctions) {
     this.sd = sd;
     this.parameter = parameterBuffer;
+    this.sqlPagingFunctions = sqlPagingFunctions;
   }
 
   /**
@@ -287,17 +289,17 @@ class CriteriaBuilderImpl implements ProcessorCriteriaBuilder { // NOSONAR
 
   @Override
   public ProcessorCriteriaQuery<Object> createQuery() {
-    return new CriteriaQueryImpl<>(Object.class, sd, this);
+    return new CriteriaQueryImpl<>(Object.class, sd, this,sqlPagingFunctions);
   }
 
   @Override
   public <T> ProcessorCriteriaQuery<T> createQuery(final Class<T> resultClass) {
-    return new CriteriaQueryImpl<>(resultClass, sd, this);
+    return new CriteriaQueryImpl<>(resultClass, sd, this, sqlPagingFunctions);
   }
 
   @Override
   public ProcessorCriteriaQuery<Tuple> createTupleQuery() {
-    return new CriteriaQueryImpl<>(Tuple.class, sd, this);
+    return new CriteriaQueryImpl<>(Tuple.class, sd, this, sqlPagingFunctions);
   }
 
   @Override

--- a/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/impl/CriteriaQueryImpl.java
+++ b/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/impl/CriteriaQueryImpl.java
@@ -53,12 +53,14 @@ class CriteriaQueryImpl<T> implements ProcessorCriteriaQuery<T>, SqlConvertible 
   private Optional<Integer> maxResults;
   private Optional<Integer> firstResult;
   private final CriteriaBuilder cb;
+  private final SqlPagingFunctions sqlPagingFunctions;
 
   CriteriaQueryImpl(final Class<T> clazz, final JPAServiceDocument sd, final AliasBuilder ab,
-      final CriteriaBuilder cb) {
+      final CriteriaBuilder cb, final SqlPagingFunctions sqlPagingFunctions ) {
     super();
     this.resultType = clazz;
     this.sd = sd;
+    this.sqlPagingFunctions = sqlPagingFunctions;
     this.where = Optional.empty();
     this.orderList = Optional.empty();
     this.groupBy = Optional.empty();
@@ -70,8 +72,8 @@ class CriteriaQueryImpl<T> implements ProcessorCriteriaQuery<T>, SqlConvertible 
     this.selectAliasBuilder = new AliasBuilder("S");
   }
 
-  CriteriaQueryImpl(final Class<T> clazz, final JPAServiceDocument sd, final CriteriaBuilder cb) {
-    this(clazz, sd, new AliasBuilder(), cb);
+  CriteriaQueryImpl(final Class<T> clazz, final JPAServiceDocument sd, final CriteriaBuilder cb, final SqlPagingFunctions sqlPagingFunctions ) {
+    this(clazz, sd, new AliasBuilder(), cb, sqlPagingFunctions);
   }
 
   @Override
@@ -112,11 +114,11 @@ class CriteriaQueryImpl<T> implements ProcessorCriteriaQuery<T>, SqlConvertible 
       ((SqlConvertible) e).asSQL(statement);
     });
     maxResults.ifPresent(limit -> statement.append(" ")
-        .append(SqlPagingFunctions.LIMIT)
+        .append(sqlPagingFunctions.LIMIT)
         .append(" ")
         .append(limit));
     firstResult.ifPresent(offset -> statement.append(" ")
-        .append(SqlPagingFunctions.OFFSET)
+        .append(sqlPagingFunctions.OFFSET)
         .append(" ")
         .append(offset));
     return statement;
@@ -405,7 +407,7 @@ class CriteriaQueryImpl<T> implements ProcessorCriteriaQuery<T>, SqlConvertible 
 
   @Override
   public <U> ProcessorSubquery<U> subquery(@Nonnull final Class<U> type) {
-    return new SubqueryImpl<>(type, this, aliasBuilder, cb);
+    return new SubqueryImpl<>(type, this, aliasBuilder, cb, sqlPagingFunctions);
   }
 
   /**

--- a/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/impl/EntityManagerWrapper.java
+++ b/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/impl/EntityManagerWrapper.java
@@ -1,5 +1,6 @@
 package com.sap.olingo.jpa.processor.cb.impl;
 
+import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -34,11 +35,14 @@ public class EntityManagerWrapper implements EntityManager { // NOSONAR
   private final EntityManager em;
   private final JPAServiceDocument sd;
   private final ParameterBuffer parameterBuffer;
+  private final SqlPagingFunctions sqlPagingFunctions;
 
-  public EntityManagerWrapper(final EntityManager em, final JPAServiceDocument sd) {
+
+  public EntityManagerWrapper(final EntityManager em, final JPAServiceDocument sd, final SqlPagingFunctions sqlPagingFunctions) {
     super();
     this.em = em;
     this.sd = sd;
+    this.sqlPagingFunctions = sqlPagingFunctions;
     this.cb = Optional.empty();
     this.parameterBuffer = new ParameterBuffer();
   }
@@ -676,7 +680,7 @@ public class EntityManagerWrapper implements EntityManager { // NOSONAR
     if (!em.isOpen())
       throw new IllegalStateException("Entity Manager had been closed");
     return cb.orElseGet(() -> {
-      cb = Optional.of(new CriteriaBuilderImpl(sd, parameterBuffer));
+      cb = Optional.of(new CriteriaBuilderImpl(sd, parameterBuffer, sqlPagingFunctions));
       return cb.get();
     });
   }

--- a/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/impl/SqlPagingFunctions.java
+++ b/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/impl/SqlPagingFunctions.java
@@ -1,23 +1,52 @@
 package com.sap.olingo.jpa.processor.cb.impl;
 
-enum SqlPagingFunctions {
-  LIMIT("LIMIT", Integer.MAX_VALUE),
-  OFFSET("OFFSET", 0);
+import java.sql.Connection;
+import java.sql.SQLException;
 
-  private final String keyWord;
-  private final int defaultValue;
+public class SqlPagingFunctions {
+  public final PagingFunction LIMIT;
+  public final PagingFunction OFFSET;
 
-  private SqlPagingFunctions(final String keyWord, final int defaultValue) {
-    this.keyWord = keyWord;
-    this.defaultValue = defaultValue;
+  public SqlPagingFunctions() {
+    LIMIT = new PagingFunction("LIMIT", Integer.MAX_VALUE);
+    OFFSET = new PagingFunction("OFFSET", 0);
   }
 
-  @Override
-  public String toString() {
-    return keyWord;
+  public SqlPagingFunctions(Connection conn) {
+    boolean issybase = false;
+    try {
+      String driver = conn.getMetaData().getURL();
+      issybase = driver.startsWith("jdbc:sybase");
+    } catch ( SQLException e ) {
+      e.printStackTrace();        
+    }
+    if ( issybase ) {  
+      LIMIT = new PagingFunction("ROWS LIMIT", Integer.MAX_VALUE);
+    } else {
+      LIMIT = new PagingFunction("LIMIT", Integer.MAX_VALUE);
+    }
+    OFFSET = new PagingFunction("OFFSET", 0);
   }
 
-  int defaultValue() {
-    return defaultValue;
+  public class PagingFunction {
+    private final String keyWord;
+    private final int defaultValue;
+
+    public PagingFunction(final String keyWord, final int defaultValue) {
+      this.keyWord = keyWord;
+      this.defaultValue = defaultValue;
+    }
+  
+    @Override
+    public String toString() {
+      return keyWord;
+    }
+  
+    int defaultValue() {
+      return defaultValue;
+    
+    }
   }
 }
+
+

--- a/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/impl/SubqueryImpl.java
+++ b/jpa/odata-jpa-processor-cb/src/main/java/com/sap/olingo/jpa/processor/cb/impl/SubqueryImpl.java
@@ -53,11 +53,11 @@ class SubqueryImpl<T> implements ProcessorSubquery<T>, SqlConvertible {
   private Optional<Integer> firstResult;
 
   SubqueryImpl(@Nonnull final Class<T> type, @Nonnull final CriteriaQuery<?> parent, final AliasBuilder ab,
-      final CriteriaBuilder cb) {
+      final CriteriaBuilder cb, final SqlPagingFunctions sqlPagingFunctions) {
     super();
     this.type = Objects.requireNonNull(type);
     this.parent = Objects.requireNonNull(parent);
-    this.inner = new CriteriaQueryImpl<>(type, ((CriteriaQueryImpl<?>) parent).getServiceDocument(), ab, cb);
+    this.inner = new CriteriaQueryImpl<>(type, ((CriteriaQueryImpl<?>) parent).getServiceDocument(), ab, cb, sqlPagingFunctions);
     maxResult = Optional.empty();
     firstResult = Optional.empty();
   }

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/api/JPAODataServiceContext.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/api/JPAODataServiceContext.java
@@ -55,6 +55,7 @@ public final class JPAODataServiceContext implements JPAODataSessionContextAcces
   private final boolean useAbsoluteContextURL;
   private final List<AnnotationProvider> annotationProvider;
   private final JPAODataQueryDirectives queryDirectives;
+  private final Object sqlPagingFunctions;
 
   public static JPAODataServiceContextBuilder with() {
     return new Builder();
@@ -78,6 +79,7 @@ public final class JPAODataServiceContext implements JPAODataSessionContextAcces
     useAbsoluteContextURL = builder.useAbsoluteContextURL;
     annotationProvider = Arrays.asList(builder.annotationProvider);
     queryDirectives = builder.queryDirectives;
+    sqlPagingFunctions = builder.sqlPagingFunctions;
   }
 
   @Override
@@ -153,6 +155,11 @@ public final class JPAODataServiceContext implements JPAODataSessionContextAcces
     return queryDirectives;
   }
 
+  @Override
+  public Object setSqlPagingFunctions(Object sqlPagingFunctions) {
+    return this.sqlPagingFunctions;
+  }
+
   static class Builder implements JPAODataServiceContextBuilder {
 
     private String namespace;
@@ -172,6 +179,7 @@ public final class JPAODataServiceContext implements JPAODataSessionContextAcces
     private boolean useAbsoluteContextURL = false;
     private AnnotationProvider[] annotationProvider;
     private JPAODataQueryDirectivesImpl queryDirectives;
+    private Object sqlPagingFunctions;
 
     private Builder() {
       super();
@@ -388,6 +396,12 @@ public final class JPAODataServiceContext implements JPAODataSessionContextAcces
       return this;
     }
 
+    @Override
+    public JPAODataServiceContextBuilder setSqlPagingFunctions(final Object sqlPagingFunctions) {
+      this.sqlPagingFunctions = sqlPagingFunctions;
+      return this;
+    }
+
     @SuppressWarnings("unchecked")
     private void createEmfWrapper() {
       if (emf.isPresent()) {
@@ -398,7 +412,7 @@ public final class JPAODataServiceContext implements JPAODataSessionContextAcces
             jpaEdm = new JPAEdmProvider(emf.get().getMetamodel(), postProcessor, packageName, nameBuilder, Arrays
                 .asList(annotationProvider));
           emf = Optional.of(wrapperClass.getConstructor(EntityManagerFactory.class,
-              JPAServiceDocument.class).newInstance(emf.get(), jpaEdm.getServiceDocument()));
+              JPAServiceDocument.class).newInstance(emf.get(), jpaEdm.getServiceDocument(), sqlPagingFunctions));
           LOGGER.trace("Criteria Builder Extension found. It will be used");
         } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
             | NoSuchMethodException | SecurityException e) {
@@ -421,5 +435,7 @@ public final class JPAODataServiceContext implements JPAODataSessionContextAcces
       this.queryDirectives = queryDirectives;
       return this;
     }
+
   }
+
 }

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/api/JPAODataServiceContextBuilder.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/api/JPAODataServiceContextBuilder.java
@@ -135,6 +135,8 @@ public interface JPAODataServiceContextBuilder {
 
   JPAODataServiceContextBuilder setAnnotationProvider(AnnotationProvider... annotationProvider);
 
+  JPAODataServiceContextBuilder setSqlPagingFunctions(Object sqlPagingFunctions);
+
   /**
    *
    */

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/api/JPAODataSessionContextAccess.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/api/JPAODataSessionContextAccess.java
@@ -68,4 +68,6 @@ public interface JPAODataSessionContextAccess {
 
   public JPAODataQueryDirectives getQueryDirectives();
 
+  public Object setSqlPagingFunctions(final Object sqlPagingFunctions);
+
 }

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAJoinCountQuery.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAJoinCountQuery.java
@@ -44,7 +44,8 @@ public class JPAJoinCountQuery extends JPAJoinQuery implements JPACountQuery {
         cq.where(whereClause);
       cq.multiselect(cb.count(target));
       final var result = em.createQuery(cq).getSingleResult();
-      return (Long) result.get(0);
+      final var cnt = result.get(0);
+	  return ((Number)cnt).longValue();
     } catch (final JPANoSelectionException e) {
       return 0L;
     }


### PR DESCRIPTION
By casting the result to number and then to long we are ensured we are not getting any cast problems.