### PR TITLE
Changes to make JPAAbstractExpandQuery available for extension

### DIFF
--- a/jpa/odata-jpa-annotation/pom.xml
+++ b/jpa/odata-jpa-annotation/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sap.olingo</groupId>
 		<artifactId>odata-jpa</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>odata-jpa-annotation</artifactId>
 	<name>odata-jpa-annotation</name>

--- a/jpa/odata-jpa-coverage/pom.xml
+++ b/jpa/odata-jpa-coverage/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.sap.olingo</groupId>
         <artifactId>odata-jpa</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>odata-jpa-coverage</artifactId>

--- a/jpa/odata-jpa-metadata/pom.xml
+++ b/jpa/odata-jpa-metadata/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
         <groupId>com.sap.olingo</groupId>
         <artifactId>odata-jpa</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>odata-jpa-metadata</artifactId>

--- a/jpa/odata-jpa-odata-vocabularies/pom.xml
+++ b/jpa/odata-jpa-odata-vocabularies/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.sap.olingo</groupId>
 		<artifactId>odata-jpa</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>odata-jpa-odata-vocabularies</artifactId>
 	<name>odata-jpa-odata-vocabularies</name>

--- a/jpa/odata-jpa-processor-cb/pom.xml
+++ b/jpa/odata-jpa-processor-cb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.sap.olingo</groupId>
         <artifactId>odata-jpa</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>odata-jpa-processor-cb</artifactId>

--- a/jpa/odata-jpa-processor-ext/pom.xml
+++ b/jpa/odata-jpa-processor-ext/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.sap.olingo</groupId>
         <artifactId>odata-jpa</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>odata-jpa-processor-ext</artifactId>
     <name>odata-jpa-processor-ext</name>

--- a/jpa/odata-jpa-processor-parallel/pom.xml
+++ b/jpa/odata-jpa-processor-parallel/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sap.olingo</groupId>
 		<artifactId>odata-jpa</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>odata-jpa-processor-parallel</artifactId>

--- a/jpa/odata-jpa-processor/pom.xml
+++ b/jpa/odata-jpa-processor/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
         <groupId>com.sap.olingo</groupId>
         <artifactId>odata-jpa</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>odata-jpa-processor</artifactId>

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/processor/JPANavigationRequestProcessor.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/processor/JPANavigationRequestProcessor.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 import jakarta.persistence.Tuple;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.olingo.commons.api.data.ComplexValue;
@@ -63,7 +64,7 @@ import com.sap.olingo.jpa.processor.core.query.JPAKeyBoundary;
 import com.sap.olingo.jpa.processor.core.query.JPANavigationPropertyInfo;
 import com.sap.olingo.jpa.processor.core.query.Utility;
 
-public final class JPANavigationRequestProcessor extends JPAAbstractGetRequestProcessor {
+public class JPANavigationRequestProcessor extends JPAAbstractGetRequestProcessor {
   private static final Log LOGGER = LogFactory.getLog(JPANavigationRequestProcessor.class);
   private final ServiceMetadata serviceMetadata;
   private final UriResource lastItem;
@@ -348,7 +349,7 @@ public final class JPANavigationRequestProcessor extends JPAAbstractGetRequestPr
 
     try (var expandMeasurement = debugger.newMeasurement(this, "readExpandEntities")) {
 
-      final var factory = new JPAExpandQueryFactory(odata, requestContext, cb);
+      final var factory = createExpandQueryFactory(odata, requestContext, cb);
       final Map<JPAAssociationPath, JPAExpandResult> allExpResults = new HashMap<>();
       if (watchDog.getRemainingLevels() > 0) {
         // x/a?$expand=b/c($expand=d,e/f)&$filter=...&$top=3&$orderBy=...
@@ -386,6 +387,12 @@ public final class JPANavigationRequestProcessor extends JPAAbstractGetRequestPr
       }
       return allExpResults;
     }
+  }
+
+  protected JPAExpandQueryFactory createExpandQueryFactory(OData odata,
+                                                           JPAODataRequestContextAccess requestContext,
+                                                           CriteriaBuilder cb) {
+    return new JPAExpandQueryFactory(odata, requestContext, cb);
   }
 
   private static Optional<JPAAnnotatable> determineTargetEntitySet(final JPAODataRequestContextAccess requestContext)

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/processor/JPAODataInternalRequestContext.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/processor/JPAODataInternalRequestContext.java
@@ -103,7 +103,7 @@ public final class JPAODataInternalRequestContext implements JPAODataRequestCont
     this(uriInfo, null, context, header);
   }
 
-  JPAODataInternalRequestContext(final JPAODataPage page, final JPASerializer serializer,
+  public JPAODataInternalRequestContext(final JPAODataPage page, final JPASerializer serializer,
       final JPAODataRequestContextAccess context, final Map<String, List<String>> header)
       throws ODataJPAIllegalAccessException, ODataJPAProcessorException {
 

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/processor/JPAProcessorFactory.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/processor/JPAProcessorFactory.java
@@ -35,11 +35,11 @@ import com.sap.olingo.jpa.processor.core.query.JPACountQuery;
 import com.sap.olingo.jpa.processor.core.query.JPAJoinCountQuery;
 import com.sap.olingo.jpa.processor.core.serializer.JPASerializerFactory;
 
-public final class JPAProcessorFactory {
-  private final JPAODataSessionContextAccess sessionContext;
-  private final JPASerializerFactory serializerFactory;
-  private final OData odata;
-  private final ServiceMetadata serviceMetadata;
+public class JPAProcessorFactory {
+  protected final JPAODataSessionContextAccess sessionContext;
+  protected final JPASerializerFactory serializerFactory;
+  protected final OData odata;
+  protected final ServiceMetadata serviceMetadata;
 
   public JPAProcessorFactory(final OData odata, final ServiceMetadata serviceMetadata,
       final JPAODataSessionContextAccess context) {
@@ -112,13 +112,13 @@ public final class JPAProcessorFactory {
 
   }
 
-  private void checkFunctionPathSupported(final List<UriResource> resourceParts) throws ODataApplicationException {
+  protected void checkFunctionPathSupported(final List<UriResource> resourceParts) throws ODataApplicationException {
     if (resourceParts.size() > 2)
       throw new ODataJPAProcessorException(ODataJPAProcessorException.MessageKeys.NOT_SUPPORTED_FUNC_WITH_NAVI,
           HttpStatusCode.NOT_IMPLEMENTED);
   }
 
-  private void checkNavigationPathSupported(final List<UriResource> resourceParts) throws ODataApplicationException {
+  protected void checkNavigationPathSupported(final List<UriResource> resourceParts) throws ODataApplicationException {
     for (final UriResource resourceItem : resourceParts) {
       if (resourceItem.getKind() != UriResourceKind.complexProperty
           && resourceItem.getKind() != UriResourceKind.primitiveProperty
@@ -132,7 +132,7 @@ public final class JPAProcessorFactory {
   }
 
   @Nonnull
-  private JPAODataPage getPage(final Map<String, List<String>> headers, final UriInfo uriInfo,
+  protected JPAODataPage getPage(final Map<String, List<String>> headers, final UriInfo uriInfo,
       final JPAODataRequestContextAccess requestContext, final JPAODataPathInformation pathInformation)
       throws ODataException {
 
@@ -159,7 +159,7 @@ public final class JPAProcessorFactory {
     return page;
   }
 
-  private Integer getPreferredPageSize(final Map<String, List<String>> headers) throws ODataJPAProcessorException {
+  protected Integer getPreferredPageSize(final Map<String, List<String>> headers) throws ODataJPAProcessorException {
 
     final var preferredHeaders = getHeader("Prefer", headers);
     if (preferredHeaders != null) {
@@ -176,7 +176,7 @@ public final class JPAProcessorFactory {
     return null;
   }
 
-  private boolean serverDrivenPaging(final UriInfo uriInfo) throws ODataJPAProcessorException {
+  protected boolean serverDrivenPaging(final UriInfo uriInfo) throws ODataJPAProcessorException {
 
     for (final SystemQueryOption option : uriInfo.getSystemQueryOptions()) {
       if (option.getKind() == SystemQueryOptionKind.SKIPTOKEN
@@ -189,7 +189,7 @@ public final class JPAProcessorFactory {
         && resourceParts.get(resourceParts.size() - 1).getKind() != UriResourceKind.function;
   }
 
-  private String skipToken(final UriInfo uriInfo) {
+  protected String skipToken(final UriInfo uriInfo) {
     for (final SystemQueryOption option : uriInfo.getSystemQueryOptions()) {
       if (option.getKind() == SystemQueryOptionKind.SKIPTOKEN)
         return option.getText();
@@ -197,7 +197,7 @@ public final class JPAProcessorFactory {
     return null;
   }
 
-  private List<String> getHeader(final String name, final Map<String, List<String>> headers) {
+  protected List<String> getHeader(final String name, final Map<String, List<String>> headers) {
     for (final Entry<String, List<String>> header : headers.entrySet()) {
       if (header.getKey().equalsIgnoreCase(name)) {
         return header.getValue();

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAAbstractExpandQuery.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAAbstractExpandQuery.java
@@ -38,7 +38,7 @@ public abstract class JPAAbstractExpandQuery extends JPAAbstractJoinQuery {
 
   protected final JPAAssociationPath association;
 
-  JPAAbstractExpandQuery(final OData odata,
+  protected JPAAbstractExpandQuery(final OData odata,
       final JPAEntityType jpaEntityType, final JPAODataRequestContextAccess requestContext,
       final JPAAssociationPath association) throws ODataException {
 
@@ -46,14 +46,14 @@ public abstract class JPAAbstractExpandQuery extends JPAAbstractJoinQuery {
     this.association = association;
   }
 
-  JPAAbstractExpandQuery(final OData odata, final JPAODataRequestContextAccess requestContext,
+  protected JPAAbstractExpandQuery(final OData odata, final JPAODataRequestContextAccess requestContext,
       final JPAInlineItemInfo item) throws ODataException {
 
     super(odata, item.getEntityType(), item.getUriInfo(), requestContext, item.getHops());
     this.association = getAssociation(item);
   }
 
-  JPAAbstractExpandQuery(final OData odata, final JPAODataRequestContextAccess requestContext, final JPAEntityType et,
+  protected JPAAbstractExpandQuery(final OData odata, final JPAODataRequestContextAccess requestContext, final JPAEntityType et,
       final JPAAssociationPath association, final List<JPANavigationPropertyInfo> hops) throws ODataException {
 
     super(odata, et, requestContext, hops);
@@ -143,7 +143,7 @@ public abstract class JPAAbstractExpandQuery extends JPAAbstractJoinQuery {
     return groupBy;
   }
 
-  abstract Map<String, Long> count() throws ODataApplicationException;
+  protected abstract Map<String, Long> count() throws ODataApplicationException;
 
   protected boolean countRequested(final JPANavigationPropertyInfo lastInfo) {
     if (lastInfo.getUriInfo() == null)

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAExpandJoinCountQuery.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAExpandJoinCountQuery.java
@@ -100,7 +100,7 @@ public final class JPAExpandJoinCountQuery extends JPAAbstractExpandQuery {
   }
 
   @Override
-  final Map<String, Long> count() throws ODataApplicationException {
+  public final Map<String, Long> count() throws ODataApplicationException {
 
     try (JPARuntimeMeasurement measurement = debugger.newMeasurement(this, "count")) {
       if (countRequested(lastInfo)) {

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAExpandJoinQuery.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAExpandJoinQuery.java
@@ -216,7 +216,7 @@ public final class JPAExpandJoinQuery extends JPAAbstractExpandQuery {
   }
 
   @Override
-  final Map<String, Long> count() throws ODataApplicationException {
+  public final Map<String, Long> count() throws ODataApplicationException {
 
     try (JPARuntimeMeasurement measurement = debugger.newMeasurement(this, "count")) {
       final JPAExpandJoinCountQuery countQuery = new JPAExpandJoinCountQuery(odata, requestContext, jpaEntity,

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAExpandQueryFactory.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAExpandQueryFactory.java
@@ -11,9 +11,9 @@ import com.sap.olingo.jpa.processor.cb.ProcessorCriteriaBuilder;
 import com.sap.olingo.jpa.processor.core.api.JPAODataRequestContextAccess;
 
 public class JPAExpandQueryFactory {
-  private final OData odata;
-  private final JPAODataRequestContextAccess requestContext;
-  private final CriteriaBuilder cb;
+  protected final OData odata;
+  protected final JPAODataRequestContextAccess requestContext;
+  protected final CriteriaBuilder cb;
 
   public JPAExpandQueryFactory(final OData odata, final JPAODataRequestContextAccess requestContext,
       final CriteriaBuilder cb) {

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAExpandSubCountQuery.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAExpandSubCountQuery.java
@@ -108,7 +108,7 @@ public final class JPAExpandSubCountQuery extends JPAAbstractExpandQuery {
   }
 
   @Override
-  final Map<String, Long> count() throws ODataApplicationException {
+  public final Map<String, Long> count() throws ODataApplicationException {
 
     try (JPARuntimeMeasurement measurement = debugger.newMeasurement(this, "count")) {
       if (countRequested(lastInfo)) {

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAExpandSubQuery.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAExpandSubQuery.java
@@ -156,7 +156,7 @@ public class JPAExpandSubQuery extends JPAAbstractExpandQuery {
   }
 
   @Override
-  final Map<String, Long> count() throws ODataApplicationException {
+  public final Map<String, Long> count() throws ODataApplicationException {
 
     try (JPARuntimeMeasurement measurement = debugger.newMeasurement(this, "count")) {
       final JPAExpandSubCountQuery countQuery = new JPAExpandSubCountQuery(odata, requestContext, jpaEntity,

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAInlineItemInfo.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAInlineItemInfo.java
@@ -11,7 +11,7 @@ import org.apache.olingo.server.api.uri.UriInfoResource;
 import com.sap.olingo.jpa.metadata.core.edm.mapper.api.JPAAssociationPath;
 import com.sap.olingo.jpa.metadata.core.edm.mapper.api.JPAEntityType;
 
-abstract class JPAInlineItemInfo {
+public abstract class JPAInlineItemInfo {
 
   protected final JPAExpandItem uriInfo;
   protected final JPAAssociationPath expandAssociation;

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPANavigationPropertyInfo.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPANavigationPropertyInfo.java
@@ -137,11 +137,11 @@ public final class JPANavigationPropertyInfo implements JPANavigationPropertyInf
     return et;
   }
 
-  JPAFilterComplier getFilterCompiler() {
+  public JPAFilterComplier getFilterCompiler() {
     return filterCompiler;
   }
 
-  From<?, ?> getFromClause() { // NOSONAR
+  public From<?, ?> getFromClause() { // NOSONAR
     return fromClause;
   }
 
@@ -150,7 +150,7 @@ public final class JPANavigationPropertyInfo implements JPANavigationPropertyInf
     return keyPredicates;
   }
 
-  UriInfoResource getUriInfo() {
+  public UriInfoResource getUriInfo() {
     return uriInfo;
   }
 

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAOrderByBuilder.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAOrderByBuilder.java
@@ -36,7 +36,7 @@ import com.sap.olingo.jpa.processor.core.properties.JPAProcessorAttribute;
  * @author Oliver Grande
  * @since 1.0.0
  */
-final class JPAOrderByBuilder {
+public final class JPAOrderByBuilder {
   private static final Log LOGGER = LogFactory.getLog(JPAOrderByBuilder.class);
   private static final String LOG_ORDER_BY = "Determined $orderby: convert to Order By";
   private final JPAEntityType jpaEntity;
@@ -45,7 +45,7 @@ final class JPAOrderByBuilder {
   private final List<String> groups;
   private final JPAOrderByBuilderWatchDog watchDog;
 
-  JPAOrderByBuilder(final JPAEntityType jpaEntity, final From<?, ?> target, final CriteriaBuilder cb,
+  public JPAOrderByBuilder(final JPAEntityType jpaEntity, final From<?, ?> target, final CriteriaBuilder cb,
       final List<String> groups) {
     super();
     this.jpaEntity = jpaEntity;
@@ -55,7 +55,7 @@ final class JPAOrderByBuilder {
     this.watchDog = new JPAOrderByBuilderWatchDog();
   }
 
-  JPAOrderByBuilder(final JPAAnnotatable annotatable, final JPAEntityType jpaEntity, final From<?, ?> target,
+  public JPAOrderByBuilder(final JPAAnnotatable annotatable, final JPAEntityType jpaEntity, final From<?, ?> target,
       final CriteriaBuilder cb, final List<String> groups) throws ODataJPAQueryException {
     super();
     this.jpaEntity = jpaEntity;
@@ -103,7 +103,7 @@ final class JPAOrderByBuilder {
    * @throws ODataApplicationException
    */
   @Nonnull
-  List<Order> createOrderByList(@Nonnull final Map<String, From<?, ?>> joinTables,
+  public List<Order> createOrderByList(@Nonnull final Map<String, From<?, ?>> joinTables,
       final List<JPAProcessorAttribute> orderByAttributes, final JPAODataPage page)
       throws ODataJPAQueryException {
 

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAQueryCreationResult.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/JPAQueryCreationResult.java
@@ -5,7 +5,7 @@ import jakarta.persistence.TypedQuery;
 
 import com.sap.olingo.jpa.metadata.core.edm.mapper.api.JPAPath;
 
-record JPAQueryCreationResult(TypedQuery<Tuple> query, SelectionPathInfo<JPAPath> selection) {
+public record JPAQueryCreationResult(TypedQuery<Tuple> query, SelectionPathInfo<JPAPath> selection) {
 
   @Override
   public String toString() {

--- a/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/SelectionPathInfo.java
+++ b/jpa/odata-jpa-processor/src/main/java/com/sap/olingo/jpa/processor/core/query/SelectionPathInfo.java
@@ -16,7 +16,7 @@ import javax.annotation.Nullable;
  *
  * @param <T>
  */
-class SelectionPathInfo<T> {
+public class SelectionPathInfo<T> {
   private final Set<T> odataSelections;
   private final Set<T> requiredSelections;
   private final Set<T> transientSelections;
@@ -45,26 +45,26 @@ class SelectionPathInfo<T> {
     this.transientSelections = new HashSet<>();
   }
 
-  Set<T> getODataSelections() {
+  public Set<T> getODataSelections() {
     return odataSelections;
   }
 
-  Set<T> getRequiredSelections() {
+  public Set<T> getRequiredSelections() {
     return requiredSelections;
   }
 
-  Set<T> getTransientSelections() {
+  public Set<T> getTransientSelections() {
     return transientSelections;
   }
 
-  Set<T> joined() {
+  public Set<T> joined() {
     final Set<T> joined = new HashSet<>(odataSelections);
     joined.addAll(requiredSelections);
     joined.addAll(transientSelections);
     return joined;
   }
 
-  Set<T> joinedPersistent() {
+  public Set<T> joinedPersistent() {
     if (joinedPersistent == null) {
       joinedPersistent = new HashSet<>(odataSelections);
       joinedPersistent.addAll(requiredSelections);
@@ -72,7 +72,7 @@ class SelectionPathInfo<T> {
     return joinedPersistent;
   }
 
-  Set<T> joinedRequested() {
+  public Set<T> joinedRequested() {
     if (joinedRequested == null) {
       joinedRequested = new HashSet<>(odataSelections);
       joinedRequested.addAll(transientSelections);

--- a/jpa/odata-jpa-spring-support/pom.xml
+++ b/jpa/odata-jpa-spring-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.sap.olingo</groupId>
         <artifactId>odata-jpa</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>odata-jpa-spring-support</artifactId>

--- a/jpa/odata-jpa-test/pom.xml
+++ b/jpa/odata-jpa-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.sap.olingo</groupId>
 		<artifactId>odata-jpa</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>odata-jpa-test</artifactId>
 	<name>odata-jpa-test</name>

--- a/jpa/odata-jpa-vocabularies/pom.xml
+++ b/jpa/odata-jpa-vocabularies/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.sap.olingo</groupId>
 		<artifactId>odata-jpa</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>odata-jpa-vocabularies</artifactId>
 	<name>odata-jpa-vocabularies</name>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.olingo</groupId>
     <artifactId>odata-jpa</artifactId>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>odata-jpa</name>
     <url>https://github.com/SAP/olingo-jpa-processor-v4</url>


### PR DESCRIPTION
Why it is needed? 
Implementation and usage of custom JPAAbstractExpandQuery is not possible in actual state. Class is public but important for extension methods and other dependent classes has package private access.